### PR TITLE
[feat] add user profiles with character scoped memory

### DIFF
--- a/backend/app/agents/routing.py
+++ b/backend/app/agents/routing.py
@@ -5,6 +5,7 @@ import logging
 import re
 
 from app.bazi import is_bazi_query
+from app.pipeline import summarize_for_log
 from app.tarot import is_tarot_query
 
 logger = logging.getLogger(__name__)
@@ -134,8 +135,4 @@ def _is_divination_query(text: str) -> bool:
     return any(pattern.search(stripped) for pattern in _DIVINATION_PATTERNS)
 
 
-def _summarize_query(text: str, limit: int = 80) -> str:
-    normalized = " ".join(text.split())
-    if len(normalized) <= limit:
-        return normalized
-    return f"{normalized[: limit - 1]}…"
+_summarize_query = summarize_for_log

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -84,6 +84,11 @@ class Settings:
     history_limit: int = int(os.getenv("HISTORY_LIMIT", "12"))
     safety_blocklist: list[str] = None  # type: ignore[assignment]
     default_character_id: str = os.getenv("DEFAULT_CHARACTER_ID", "luna")
+    mem0_api_key: str | None = os.getenv("MEM0_API_KEY")
+    mem0_enabled: bool = _bool_env("MEM0_ENABLED", bool(os.getenv("MEM0_API_KEY")))
+    memory_search_limit: int = int(os.getenv("MEMORY_SEARCH_LIMIT", "5"))
+    memory_curator_provider: str | None = os.getenv("MEMORY_CURATOR_PROVIDER")
+    memory_curator_temperature: float = float(os.getenv("MEMORY_CURATOR_TEMPERATURE", "0.0"))
 
     def __post_init__(self) -> None:
         if self.allowed_origins is None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,11 +13,19 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 from app.agents import DeepAgentRuntime, SelectiveAgentRouter
 from app.characters import load_default_registry
 from app.config import settings
+from app.memory import (
+    MemoryCuratorAgent,
+    MemoryRecord,
+    MemoryService,
+    compose_memory_context,
+)
 from app.models import (
     ChatStreamRequest,
     SessionControlRequest,
     SessionMuteRequest,
     TTSRequest,
+    UserCreateRequest,
+    UserUpdateRequest,
 )
 from app.pipeline import SegmentAccumulator, detect_emotion, sse_pack
 from app.providers.base import ProviderError
@@ -44,6 +52,8 @@ events = SessionEventBus()
 providers = ProviderRegistry()
 agent_router = SelectiveAgentRouter()
 agent_runtime = DeepAgentRuntime()
+memory_service = MemoryService(settings.mem0_api_key, settings.mem0_enabled)
+memory_curator = MemoryCuratorAgent(providers)
 characters = load_default_registry()
 if not characters.has(settings.default_character_id):
     raise RuntimeError(
@@ -77,6 +87,29 @@ async def list_characters() -> dict[str, object]:
         "default_character_id": settings.default_character_id,
         "characters": characters.list_summaries(),
     }
+
+
+@app.get("/api/users")
+async def list_users() -> dict[str, object]:
+    return {"users": store.list_users()}
+
+
+@app.post("/api/users")
+async def create_user(payload: UserCreateRequest) -> dict[str, object]:
+    name = payload.name.strip()
+    if not name:
+        raise HTTPException(status_code=422, detail="User name is required.")
+    return {"user": store.create_user(name, payload.bio)}
+
+
+@app.patch("/api/users/{user_id}")
+async def update_user(user_id: int, payload: UserUpdateRequest) -> dict[str, object]:
+    if payload.name is not None and not payload.name.strip():
+        raise HTTPException(status_code=422, detail="User name is required.")
+    user = store.update_user(user_id, name=payload.name, bio=payload.bio)
+    if user is None:
+        raise HTTPException(status_code=404, detail="Unknown user_id")
+    return {"user": user}
 
 
 @app.post("/api/session/reset")
@@ -170,13 +203,18 @@ async def chat_stream(payload: ChatStreamRequest):
     llm_provider_name = _provider_name(payload.llm_provider, settings.default_llm_provider)
     tts_provider_name = _provider_name(payload.tts_provider, settings.default_tts_provider)
     character_id = payload.character_id or settings.default_character_id
+    user = store.get_user(payload.user_id)
+    if user is None:
+        raise HTTPException(status_code=400, detail="Unknown user_id")
     if not characters.has(character_id):
         raise HTTPException(status_code=400, detail=f"Unknown character_id: {character_id}")
-    persona = characters.get(character_id).to_system_prompt()
+    character = characters.get(character_id)
+    persona = character.to_system_prompt()
 
     async def generator():
         turn_start = time.perf_counter()
         controls.clear_stop(session_id)
+        relevant_memories: list[MemoryRecord] = []
 
         safe_input = safety.filter_input(payload.message)
         if not safe_input.allowed:
@@ -196,8 +234,24 @@ async def chat_stream(payload: ChatStreamRequest):
             await events.publish(session_id, StageEvent(event="done", payload={"text": ""}))
             return
 
-        store.add_message(session_id, "user", safe_input.text)
-        history = store.get_history(session_id, settings.history_limit)
+        store.add_message(session_id, "user", safe_input.text, payload.user_id, character_id)
+        try:
+            relevant_memories = await memory_service.search_memories(
+                query=safe_input.text,
+                user_id=payload.user_id,
+                character_id=character_id,
+                limit=settings.memory_search_limit,
+            )
+        except Exception as exc:
+            logger.warning("Mem0 search failed: %s", exc)
+            store.log_error(
+                session_id,
+                "memory_search",
+                str(exc),
+                {"user_id": payload.user_id, "character_id": character_id},
+            )
+            relevant_memories = []
+        history = store.get_scoped_history(payload.user_id, character_id, settings.history_limit)
         route = agent_router.decide(safe_input.text)
         print(f'Chat stream selected route: session_id={session_id} mode={route.mode} skills={route.skill_names} message={_summarize_for_log(safe_input.text)}')
         accumulator = SegmentAccumulator()
@@ -218,7 +272,11 @@ async def chat_stream(payload: ChatStreamRequest):
 
         try:
             reply_stream: AsyncIterator[str]
-            system_prompt = persona
+            system_prompt = compose_memory_context(
+                system_prompt=persona,
+                user=user,
+                memories=relevant_memories,
+            )
             llm_messages = history
             metric_provider_name = llm_provider_name
 
@@ -320,7 +378,7 @@ async def chat_stream(payload: ChatStreamRequest):
 
         full_text = "".join(full_output_parts).strip()
         if full_text:
-            store.add_message(session_id, "assistant", full_text)
+            store.add_message(session_id, "assistant", full_text, payload.user_id, character_id)
 
         total_ms = (time.perf_counter() - turn_start) * 1000
         store.log_metric(session_id, "turn_total_ms", total_ms, llm_provider_name)
@@ -329,6 +387,22 @@ async def chat_stream(payload: ChatStreamRequest):
         done_payload = {"text": full_text, "blocked": False}
         yield sse_pack("done", done_payload)
         await events.publish(session_id, StageEvent(event="done", payload=done_payload))
+        if full_text and memory_service.enabled:
+            asyncio.create_task(
+                _curate_and_store_memory(
+                    session_id=session_id,
+                    user=user,
+                    character_id=character_id,
+                    character_name=character.profile.name,
+                    user_message=safe_input.text,
+                    assistant_response=full_text,
+                    existing_memories=relevant_memories,
+                    provider_name=_provider_name(
+                        settings.memory_curator_provider,
+                        llm_provider_name,
+                    ),
+                )
+            )
 
     return StreamingResponse(
         generator(),
@@ -339,6 +413,69 @@ async def chat_stream(payload: ChatStreamRequest):
             "X-Accel-Buffering": "no",
         },
     )
+
+
+async def _curate_and_store_memory(
+    *,
+    session_id: str,
+    user: dict[str, object],
+    character_id: str,
+    character_name: str,
+    user_message: str,
+    assistant_response: str,
+    existing_memories: list[MemoryRecord],
+    provider_name: str,
+) -> None:
+    try:
+        decision = await memory_curator.curate(
+            user=user,
+            character_id=character_id,
+            character_name=character_name,
+            user_message=user_message,
+            assistant_response=assistant_response,
+            existing_memories=existing_memories,
+            provider_name=provider_name,
+        )
+    except Exception as exc:
+        logger.warning("Memory curator failed: %s", exc)
+        store.log_error(
+            session_id,
+            "memory_curator",
+            str(exc),
+            {"user_id": user.get("id"), "character_id": character_id},
+        )
+        return
+
+    if not decision.should_store:
+        return
+
+    records = [
+        MemoryRecord(
+            content=memory.content,
+            metadata={
+                "character_id": character_id,
+                "source": "chat",
+                "category": memory.category,
+                "sensitivity": memory.sensitivity,
+            },
+        )
+        for memory in decision.memories
+    ]
+    try:
+        await memory_service.add_memories(
+            memories=records,
+            user_id=int(user["id"]),
+            character_id=character_id,
+            run_id=session_id,
+        )
+    except Exception as exc:
+        logger.warning("Mem0 add failed: %s", exc)
+        store.log_error(
+            session_id,
+            "memory_add",
+            str(exc),
+            {"user_id": user.get("id"), "character_id": character_id},
+        )
 
 
 @app.exception_handler(Exception)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,8 +4,6 @@ import asyncio
 import logging
 import time
 from collections.abc import AsyncIterator
-from datetime import datetime, timezone
-
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response, StreamingResponse
@@ -27,11 +25,11 @@ from app.models import (
     UserCreateRequest,
     UserUpdateRequest,
 )
-from app.pipeline import SegmentAccumulator, detect_emotion, sse_pack
+from app.pipeline import SegmentAccumulator, detect_emotion, sse_pack, summarize_for_log
 from app.providers.base import ProviderError
 from app.providers.registry import ProviderRegistry
 from app.safety import SafetyPipeline
-from app.session_store import SessionControl, SessionEventBus, SessionStore, StageEvent
+from app.session_store import SessionControl, SessionEventBus, SessionStore, StageEvent, now_iso
 
 logger = logging.getLogger(__name__)
 
@@ -61,24 +59,14 @@ if not characters.has(settings.default_character_id):
     )
 
 
-def _now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat()
-
-
 def _provider_name(requested: str | None, default_name: str) -> str:
     return (requested or default_name).lower()
 
 
-def _summarize_for_log(text: str, limit: int = 80) -> str:
-    normalized = " ".join(text.split())
-    if len(normalized) <= limit:
-        return normalized
-    return f"{normalized[: limit - 1]}…"
-
 
 @app.get("/health")
 async def health() -> dict[str, str]:
-    return {"status": "ok", "time": _now_iso()}
+    return {"status": "ok", "time": now_iso()}
 
 
 @app.get("/api/characters")
@@ -235,25 +223,33 @@ async def chat_stream(payload: ChatStreamRequest):
             return
 
         store.add_message(session_id, "user", safe_input.text, payload.user_id, character_id)
-        try:
-            relevant_memories = await memory_service.search_memories(
-                query=safe_input.text,
-                user_id=payload.user_id,
-                character_id=character_id,
-                limit=settings.memory_search_limit,
-            )
-        except Exception as exc:
-            logger.warning("Mem0 search failed: %s", exc)
-            store.log_error(
-                session_id,
-                "memory_search",
-                str(exc),
-                {"user_id": payload.user_id, "character_id": character_id},
-            )
-            relevant_memories = []
-        history = store.get_scoped_history(payload.user_id, character_id, settings.history_limit)
+
+        async def _search_memories() -> list[MemoryRecord]:
+            try:
+                return await memory_service.search_memories(
+                    query=safe_input.text,
+                    user_id=payload.user_id,
+                    character_id=character_id,
+                    limit=settings.memory_search_limit,
+                )
+            except Exception as exc:
+                logger.warning("Mem0 search failed: %s", exc)
+                store.log_error(
+                    session_id,
+                    "memory_search",
+                    str(exc),
+                    {"user_id": payload.user_id, "character_id": character_id},
+                )
+                return []
+
+        relevant_memories, history = await asyncio.gather(
+            _search_memories(),
+            asyncio.to_thread(
+                store.get_scoped_history, payload.user_id, character_id, settings.history_limit
+            ),
+        )
         route = agent_router.decide(safe_input.text)
-        print(f'Chat stream selected route: session_id={session_id} mode={route.mode} skills={route.skill_names} message={_summarize_for_log(safe_input.text)}')
+        print(f'Chat stream selected route: session_id={session_id} mode={route.mode} skills={route.skill_names} message={summarize_for_log(safe_input.text)}')
         accumulator = SegmentAccumulator()
         full_output_parts: list[str] = []
         segment_index = 0
@@ -265,7 +261,7 @@ async def chat_stream(payload: ChatStreamRequest):
             "tts_provider": tts_provider_name,
             "mode": route.mode,
             "skills": route.skill_names,
-            "timestamp": _now_iso(),
+            "timestamp": now_iso(),
         }
         yield sse_pack("start", start_payload)
         await events.publish(session_id, StageEvent(event="start", payload=start_payload))

--- a/backend/app/memory.py
+++ b/backend/app/memory.py
@@ -195,12 +195,8 @@ def _parse_curator_decision(raw_output: str) -> CuratorDecision:
     except (json.JSONDecodeError, ValidationError) as exc:
         raise ProviderError(f"Memory curator returned invalid JSON: {exc}") from exc
     if not decision.should_store:
-        return CuratorDecision(should_store=False, memories=[])
-    memories = [
-        memory
-        for memory in decision.memories
-        if memory.sensitivity == "normal" and memory.content.strip()
-    ]
+        return decision
+    memories = [m for m in decision.memories if m.sensitivity == "normal" and m.content.strip()]
     return CuratorDecision(should_store=bool(memories), memories=memories)
 
 

--- a/backend/app/memory.py
+++ b/backend/app/memory.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel, Field, ValidationError
+
+from app.config import settings
+from app.providers.base import ProviderError
+
+if TYPE_CHECKING:
+    from app.providers.registry import ProviderRegistry
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class MemoryRecord:
+    content: str
+    metadata: dict[str, Any]
+
+
+class MemoryService:
+    def __init__(self, api_key: str | None, enabled: bool) -> None:
+        self.enabled = enabled and bool(api_key)
+        self._api_key = api_key
+        self._client: Any | None = None
+
+    def _get_client(self) -> Any | None:
+        if not self.enabled:
+            return None
+        if self._client is not None:
+            return self._client
+        try:
+            from mem0 import MemoryClient
+        except Exception as exc:
+            logger.warning("Mem0 SDK is unavailable; long-term memory disabled: %s", exc)
+            self.enabled = False
+            return None
+        self._client = MemoryClient(api_key=self._api_key)
+        return self._client
+
+    async def search_memories(
+        self,
+        *,
+        query: str,
+        user_id: int,
+        character_id: str,
+        limit: int,
+    ) -> list[MemoryRecord]:
+        client = self._get_client()
+        if client is None:
+            return []
+
+        def _search() -> Any:
+            return client.search(
+                query,
+                user_id=str(user_id),
+                agent_id=character_id,
+                top_k=limit,
+            )
+
+        raw_results = await asyncio.to_thread(_search)
+        return _normalize_memory_results(raw_results, limit)
+
+    async def add_memories(
+        self,
+        *,
+        memories: list[MemoryRecord],
+        user_id: int,
+        character_id: str,
+        run_id: str,
+    ) -> None:
+        client = self._get_client()
+        if client is None or not memories:
+            return
+
+        def _add_all() -> None:
+            for memory in memories:
+                client.add(
+                    memory.content,
+                    user_id=str(user_id),
+                    agent_id=character_id,
+                    run_id=run_id,
+                    metadata=memory.metadata,
+                )
+
+        await asyncio.to_thread(_add_all)
+
+
+class CuratedMemory(BaseModel):
+    content: str = Field(min_length=1, max_length=1000)
+    category: Literal["preference", "profile", "relationship", "goal", "context"] = "context"
+    sensitivity: Literal["normal", "sensitive"] = "normal"
+
+
+class CuratorDecision(BaseModel):
+    should_store: bool = False
+    memories: list[CuratedMemory] = Field(default_factory=list)
+
+
+class MemoryCuratorAgent:
+    def __init__(self, providers: ProviderRegistry) -> None:
+        self._providers = providers
+
+    async def curate(
+        self,
+        *,
+        user: dict[str, Any],
+        character_id: str,
+        character_name: str,
+        user_message: str,
+        assistant_response: str,
+        existing_memories: list[MemoryRecord],
+        provider_name: str,
+    ) -> CuratorDecision:
+        llm = self._providers.llm(provider_name)
+        prompt = _build_curator_prompt(
+            user=user,
+            character_id=character_id,
+            character_name=character_name,
+            user_message=user_message,
+            assistant_response=assistant_response,
+            existing_memories=existing_memories,
+        )
+        output_parts: list[str] = []
+        async for chunk in llm.stream_reply(
+            [{"role": "user", "content": prompt}],
+            _CURATOR_SYSTEM_PROMPT,
+            settings.memory_curator_temperature,
+        ):
+            output_parts.append(chunk)
+        return _parse_curator_decision("".join(output_parts))
+
+
+def compose_memory_context(
+    *,
+    system_prompt: str,
+    user: dict[str, Any],
+    memories: list[MemoryRecord],
+) -> str:
+    sections = [system_prompt.rstrip()]
+    profile_lines = [f"Name: {user['name']}"]
+    if user.get("bio"):
+        profile_lines.append(f"Bio: {user['bio']}")
+    sections.append("Current user profile:\n" + "\n".join(profile_lines))
+
+    if memories:
+        memory_lines = [f"- {memory.content}" for memory in memories if memory.content]
+        if memory_lines:
+            sections.append("Relevant long-term memories for this user and character:\n" + "\n".join(memory_lines))
+
+    return "\n\n".join(section for section in sections if section)
+
+
+def _normalize_memory_results(raw_results: Any, limit: int) -> list[MemoryRecord]:
+    if isinstance(raw_results, dict):
+        candidates = raw_results.get("results") or raw_results.get("memories") or []
+    elif isinstance(raw_results, list):
+        candidates = raw_results
+    else:
+        candidates = []
+
+    records: list[MemoryRecord] = []
+    for item in candidates[:limit]:
+        if isinstance(item, str):
+            records.append(MemoryRecord(content=item, metadata={}))
+            continue
+        if not isinstance(item, dict):
+            continue
+        content = item.get("memory") or item.get("content") or item.get("text")
+        if not isinstance(content, str) or not content.strip():
+            continue
+        metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+        records.append(MemoryRecord(content=content.strip(), metadata=metadata))
+    return records
+
+
+def _parse_curator_decision(raw_output: str) -> CuratorDecision:
+    text = raw_output.strip()
+    if text.startswith("```"):
+        text = text.strip("`")
+        if text.lower().startswith("json"):
+            text = text[4:].strip()
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end != -1 and end >= start:
+        text = text[start : end + 1]
+    try:
+        payload = json.loads(text)
+        decision = CuratorDecision.model_validate(payload)
+    except (json.JSONDecodeError, ValidationError) as exc:
+        raise ProviderError(f"Memory curator returned invalid JSON: {exc}") from exc
+    if not decision.should_store:
+        return CuratorDecision(should_store=False, memories=[])
+    memories = [
+        memory
+        for memory in decision.memories
+        if memory.sensitivity == "normal" and memory.content.strip()
+    ]
+    return CuratorDecision(should_store=bool(memories), memories=memories)
+
+
+def _build_curator_prompt(
+    *,
+    user: dict[str, Any],
+    character_id: str,
+    character_name: str,
+    user_message: str,
+    assistant_response: str,
+    existing_memories: list[MemoryRecord],
+) -> str:
+    existing = "\n".join(f"- {memory.content}" for memory in existing_memories) or "(none)"
+    return f"""
+User profile:
+- id: {user['id']}
+- name: {user['name']}
+- bio: {user.get('bio') or '(empty)'}
+
+Character:
+- id: {character_id}
+- name: {character_name}
+
+Relevant existing memories:
+{existing}
+
+Latest user message:
+{user_message}
+
+Latest assistant response:
+{assistant_response}
+
+Return only JSON matching this shape:
+{{
+  "should_store": true,
+  "memories": [
+    {{
+      "content": "Stable fact worth remembering.",
+      "category": "preference",
+      "sensitivity": "normal"
+    }}
+  ]
+}}
+""".strip()
+
+
+_CURATOR_SYSTEM_PROMPT = """
+You decide whether a VTuber app should store long-term memories.
+Store stable facts, preferences, goals, recurring context, and relationship context.
+Do not store one-off small talk.
+Do not store sensitive information unless the user explicitly asked the character to remember it.
+Do not store unsafe instructions, secrets, credentials, or private identifiers.
+Return only valid JSON. Use should_store false and an empty memories list when nothing is useful.
+""".strip()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -23,11 +23,22 @@ class ChatMessage(BaseModel):
 
 class ChatStreamRequest(BaseModel):
     session_id: str = Field(min_length=1, max_length=128)
+    user_id: int = Field(ge=1)
     message: str = Field(min_length=1, max_length=4000)
     llm_provider: LLMProviderName | None = None
     tts_provider: TTSProviderName | None = None
     character_id: str | None = Field(default=None, max_length=64)
     temperature: float = Field(default=0.7, ge=0.0, le=1.5)
+
+
+class UserCreateRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=80)
+    bio: str = Field(default="", max_length=1200)
+
+
+class UserUpdateRequest(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=80)
+    bio: str | None = Field(default=None, max_length=1200)
 
 
 class TTSRequest(BaseModel):

--- a/backend/app/pipeline.py
+++ b/backend/app/pipeline.py
@@ -37,6 +37,13 @@ class SegmentAccumulator:
         return remaining
 
 
+def summarize_for_log(text: str, limit: int = 80) -> str:
+    normalized = " ".join(text.split())
+    if len(normalized) <= limit:
+        return normalized
+    return f"{normalized[: limit - 1]}…"
+
+
 def detect_emotion(text: str) -> str:
     source = text.lower()
     if any(token in source for token in ["驚", "wow", "surprise", "真的假的"]):

--- a/backend/app/session_store.py
+++ b/backend/app/session_store.py
@@ -39,9 +39,19 @@ class SessionStore:
             cursor = self._conn.cursor()
             cursor.executescript(
                 """
+                CREATE TABLE IF NOT EXISTS users (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    bio TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+
                 CREATE TABLE IF NOT EXISTS messages (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     session_id TEXT NOT NULL,
+                    user_id INTEGER,
+                    character_id TEXT,
                     role TEXT NOT NULL,
                     content TEXT NOT NULL,
                     created_at TEXT NOT NULL
@@ -70,16 +80,105 @@ class SessionStore:
                 );
                 """
             )
+            existing_message_columns = {
+                row["name"] for row in cursor.execute("PRAGMA table_info(messages)").fetchall()
+            }
+            if "user_id" not in existing_message_columns:
+                cursor.execute("ALTER TABLE messages ADD COLUMN user_id INTEGER")
+            if "character_id" not in existing_message_columns:
+                cursor.execute("ALTER TABLE messages ADD COLUMN character_id TEXT")
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_messages_user_character_created
+                ON messages (user_id, character_id, created_at)
+                """
+            )
             self._conn.commit()
 
-    def add_message(self, session_id: str, role: str, content: str) -> None:
+    def create_user(self, name: str, bio: str = "") -> dict[str, Any]:
+        timestamp = now_iso()
+        clean_name = name.strip()
+        clean_bio = bio.strip()
+        with _locked(self._lock):
+            cursor = self._conn.execute(
+                """
+                INSERT INTO users (name, bio, created_at, updated_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (clean_name, clean_bio, timestamp, timestamp),
+            )
+            self._conn.commit()
+            user_id = int(cursor.lastrowid)
+        user = self.get_user(user_id)
+        if user is None:  # pragma: no cover - defensive consistency check
+            raise RuntimeError("Created user could not be loaded.")
+        return user
+
+    def list_users(self) -> list[dict[str, Any]]:
+        with _locked(self._lock):
+            rows = self._conn.execute(
+                """
+                SELECT id, name, bio, created_at, updated_at
+                FROM users
+                ORDER BY updated_at DESC, id DESC
+                """
+            ).fetchall()
+        return [self._user_from_row(row) for row in rows]
+
+    def get_user(self, user_id: int) -> dict[str, Any] | None:
+        with _locked(self._lock):
+            row = self._conn.execute(
+                """
+                SELECT id, name, bio, created_at, updated_at
+                FROM users
+                WHERE id = ?
+                """,
+                (user_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._user_from_row(row)
+
+    def update_user(
+        self,
+        user_id: int,
+        *,
+        name: str | None = None,
+        bio: str | None = None,
+    ) -> dict[str, Any] | None:
+        existing = self.get_user(user_id)
+        if existing is None:
+            return None
+
+        next_name = existing["name"] if name is None else name.strip()
+        next_bio = existing["bio"] if bio is None else bio.strip()
         with _locked(self._lock):
             self._conn.execute(
                 """
-                INSERT INTO messages (session_id, role, content, created_at)
-                VALUES (?, ?, ?, ?)
+                UPDATE users
+                SET name = ?, bio = ?, updated_at = ?
+                WHERE id = ?
                 """,
-                (session_id, role, content, now_iso()),
+                (next_name, next_bio, now_iso(), user_id),
+            )
+            self._conn.commit()
+        return self.get_user(user_id)
+
+    def add_message(
+        self,
+        session_id: str,
+        role: str,
+        content: str,
+        user_id: int | None = None,
+        character_id: str | None = None,
+    ) -> None:
+        with _locked(self._lock):
+            self._conn.execute(
+                """
+                INSERT INTO messages (session_id, user_id, character_id, role, content, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (session_id, user_id, character_id, role, content, now_iso()),
             )
             self._conn.commit()
 
@@ -97,6 +196,34 @@ class SessionStore:
             ).fetchall()
         history = [{"role": row["role"], "content": row["content"]} for row in reversed(rows)]
         return history
+
+    def get_scoped_history(
+        self,
+        user_id: int,
+        character_id: str,
+        limit: int,
+    ) -> list[dict[str, str]]:
+        with _locked(self._lock):
+            rows = self._conn.execute(
+                """
+                SELECT role, content
+                FROM messages
+                WHERE user_id = ? AND character_id = ?
+                ORDER BY id DESC
+                LIMIT ?
+                """,
+                (user_id, character_id, limit),
+            ).fetchall()
+        return [{"role": row["role"], "content": row["content"]} for row in reversed(rows)]
+
+    def _user_from_row(self, row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "id": row["id"],
+            "name": row["name"],
+            "bio": row["bio"],
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        }
 
     def reset_session(self, session_id: str) -> None:
         with _locked(self._lock):

--- a/backend/app/session_store.py
+++ b/backend/app/session_store.py
@@ -109,10 +109,13 @@ class SessionStore:
             )
             self._conn.commit()
             user_id = int(cursor.lastrowid)
-        user = self.get_user(user_id)
-        if user is None:  # pragma: no cover - defensive consistency check
-            raise RuntimeError("Created user could not be loaded.")
-        return user
+        return {
+            "id": user_id,
+            "name": clean_name,
+            "bio": clean_bio,
+            "created_at": timestamp,
+            "updated_at": timestamp,
+        }
 
     def list_users(self) -> list[dict[str, Any]]:
         with _locked(self._lock):
@@ -152,6 +155,7 @@ class SessionStore:
 
         next_name = existing["name"] if name is None else name.strip()
         next_bio = existing["bio"] if bio is None else bio.strip()
+        updated_at = now_iso()
         with _locked(self._lock):
             self._conn.execute(
                 """
@@ -159,10 +163,10 @@ class SessionStore:
                 SET name = ?, bio = ?, updated_at = ?
                 WHERE id = ?
                 """,
-                (next_name, next_bio, now_iso(), user_id),
+                (next_name, next_bio, updated_at, user_id),
             )
             self._conn.commit()
-        return self.get_user(user_id)
+        return {**existing, "name": next_name, "bio": next_bio, "updated_at": updated_at}
 
     def add_message(
         self,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,7 @@ langchain-core>=0.3.79
 langchain-openai>=0.3.33
 langchain-google-genai>=2.1.12
 deepagents==0.4.10
+mem0ai>=0.1.118
 numpy==2.3.3
 qwen-tts==0.1.1
 pytest==8.4.2

--- a/backend/tests/test_user_memory.py
+++ b/backend/tests/test_user_memory.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.memory import _parse_curator_decision
+from app.session_store import SessionStore
+
+
+def test_user_crud_and_scoped_history(tmp_path: Path):
+    store = SessionStore(str(tmp_path / "test.db"))
+    luna_user = store.create_user("Shane", "Likes concise replies")
+    other_user = store.create_user("Alex", "")
+
+    assert store.list_users()[0]["id"] == other_user["id"]
+    updated = store.update_user(luna_user["id"], bio="Likes relaxed divination")
+    assert updated is not None
+    assert updated["bio"] == "Likes relaxed divination"
+
+    store.add_message("session-a", "user", "for luna", luna_user["id"], "luna")
+    store.add_message("session-a", "assistant", "luna reply", luna_user["id"], "luna")
+    store.add_message("session-b", "user", "for aria", luna_user["id"], "aria")
+    store.add_message("session-c", "user", "other user", other_user["id"], "luna")
+
+    assert store.get_scoped_history(luna_user["id"], "luna", 10) == [
+        {"role": "user", "content": "for luna"},
+        {"role": "assistant", "content": "luna reply"},
+    ]
+
+
+def test_curator_parser_filters_sensitive_memories():
+    decision = _parse_curator_decision(
+        """
+        ```json
+        {
+          "should_store": true,
+          "memories": [
+            {"content": "User likes relaxed tarot readings.", "category": "preference", "sensitivity": "normal"},
+            {"content": "User shared a secret token.", "category": "profile", "sensitivity": "sensitive"}
+          ]
+        }
+        ```
+        """
+    )
+
+    assert decision.should_store is True
+    assert [memory.content for memory in decision.memories] == [
+        "User likes relaxed tarot readings."
+    ]
+
+
+def test_chat_rejects_unknown_user_id(monkeypatch, tmp_path: Path):
+    from app import main
+
+    test_store = SessionStore(str(tmp_path / "test.db"))
+    monkeypatch.setattr(main, "store", test_store)
+    client = TestClient(main.app)
+
+    response = client.post(
+        "/api/chat/stream",
+        json={
+            "session_id": "session-test",
+            "user_id": 999,
+            "message": "hello",
+            "llm_provider": "openai",
+            "tts_provider": "openai",
+            "character_id": "luna",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unknown user_id"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,7 +33,7 @@ function createMessage(role, content) {
 }
 
 function ChatPage() {
-  const [messages, setMessages] = useState([]);
+  const [messagesByScope, setMessagesByScope] = useState({});
   const [draft, setDraft] = useState("");
   const [assistantDraft, setAssistantDraft] = useState("");
   const [subtitle, setSubtitle] = useState("");
@@ -53,6 +53,9 @@ function ChatPage() {
     return saved ? Number(saved) : null;
   });
   const [usersLoading, setUsersLoading] = useState(true);
+
+  const scopeKey = selectedUserId && characterId ? `${selectedUserId}:${characterId}` : null;
+  const messages = scopeKey ? (messagesByScope[scopeKey] || []) : [];
 
   useEffect(() => {
     let cancelled = false;
@@ -155,7 +158,7 @@ function ChatPage() {
   const handleReset = async () => {
     await handleStop();
     await resetSession(sessionId);
-    setMessages([]);
+    if (scopeKey) setMessagesByScope((prev) => ({ ...prev, [scopeKey]: [] }));
     setAssistantDraft("");
     setSubtitle("");
     setExpression("neutral");
@@ -166,6 +169,18 @@ function ChatPage() {
     const next = !muted;
     setMuted(next);
     await setSessionMute(sessionId, next);
+  };
+
+  const handleChangeCharacter = (newCharacterId) => {
+    setCharacterId(newCharacterId);
+    setAssistantDraft("");
+    setError("");
+  };
+
+  const handleChangeUser = (newUserId) => {
+    setSelectedUserId(newUserId);
+    setAssistantDraft("");
+    setError("");
   };
 
   const handleCreateUser = async ({ name, bio }) => {
@@ -198,10 +213,19 @@ function ChatPage() {
     draftRef.current = "";
     finalTextRef.current = "";
     resetStop();
-    setMessages((prev) => [...prev, createMessage("user", text)]);
 
     const controller = new AbortController();
     abortRef.current = controller;
+    const key = scopeKey;
+    const addMsg = (role, content) => {
+      if (!key) return;
+      setMessagesByScope((prev) => ({
+        ...prev,
+        [key]: [...(prev[key] || []), createMessage(role, content)],
+      }));
+    };
+
+    addMsg("user", text);
 
     try {
       await streamChat(
@@ -247,7 +271,7 @@ function ChatPage() {
       abortRef.current = null;
       const finalText = (finalTextRef.current || draftRef.current).trim();
       if (finalText) {
-        setMessages((prev) => [...prev, createMessage("assistant", finalText)]);
+        addMsg("assistant", finalText);
       }
       setAssistantDraft("");
       draftRef.current = "";
@@ -290,8 +314,8 @@ function ChatPage() {
         onToggleMute={handleToggleMute}
         onChangeLLM={setLLMProvider}
         onChangeTTS={setTTSProvider}
-        onChangeCharacter={setCharacterId}
-        onChangeUser={setSelectedUserId}
+        onChangeCharacter={handleChangeCharacter}
+        onChangeUser={handleChangeUser}
         onCreateUser={handleCreateUser}
         onUpdateUser={handleUpdateUser}
       />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,12 +2,15 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import ChatPanel from "./components/ChatPanel";
 import Live2DStage from "./components/Live2DStage";
 import {
+  createUser,
   getCharacters,
+  getUsers,
   resetSession,
   setSessionMute,
   stopSession,
   streamChat,
-  subscribeStage
+  subscribeStage,
+  updateUser
 } from "./lib/api";
 import { useSpeechQueue } from "./lib/useSpeechQueue";
 
@@ -44,6 +47,12 @@ function ChatPage() {
   const [ttsProvider, setTTSProvider] = useState(DEFAULT_TTS_PROVIDER);
   const [characters, setCharacters] = useState([]);
   const [characterId, setCharacterId] = useState(null);
+  const [users, setUsers] = useState([]);
+  const [selectedUserId, setSelectedUserId] = useState(() => {
+    const saved = window.localStorage.getItem("ai_vtuber_user_id");
+    return saved ? Number(saved) : null;
+  });
+  const [usersLoading, setUsersLoading] = useState(true);
 
   useEffect(() => {
     let cancelled = false;
@@ -55,6 +64,36 @@ function ChatPage() {
       })
       .catch(() => {
         // selector will stay empty; /chat will fall back to backend default
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setUsersLoading(true);
+    getUsers()
+      .then((data) => {
+        if (cancelled) return;
+        const nextUsers = data.users || [];
+        setUsers(nextUsers);
+        setSelectedUserId((prev) => {
+          if (prev && nextUsers.some((user) => user.id === prev)) {
+            return prev;
+          }
+          return nextUsers[0]?.id || null;
+        });
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err.message);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setUsersLoading(false);
+        }
       });
     return () => {
       cancelled = true;
@@ -76,6 +115,14 @@ function ChatPage() {
   useEffect(() => {
     window.localStorage.setItem("ai_vtuber_session_id", sessionId);
   }, [sessionId]);
+
+  useEffect(() => {
+    if (selectedUserId) {
+      window.localStorage.setItem("ai_vtuber_user_id", String(selectedUserId));
+    } else {
+      window.localStorage.removeItem("ai_vtuber_user_id");
+    }
+  }, [selectedUserId]);
 
   const { enqueue, stop, resetStop } = useSpeechQueue({
     sessionId,
@@ -121,10 +168,26 @@ function ChatPage() {
     await setSessionMute(sessionId, next);
   };
 
+  const handleCreateUser = async ({ name, bio }) => {
+    setError("");
+    const data = await createUser({ name, bio });
+    const user = data.user;
+    setUsers((prev) => [user, ...prev.filter((item) => item.id !== user.id)]);
+    setSelectedUserId(user.id);
+  };
+
+  const handleUpdateUser = async (userId, updates) => {
+    setError("");
+    const data = await updateUser(userId, updates);
+    const user = data.user;
+    setUsers((prev) => prev.map((item) => (item.id === user.id ? user : item)));
+    setSelectedUserId(user.id);
+  };
+
   const handleSubmit = async (event) => {
     event.preventDefault();
     const text = draft.trim();
-    if (!text || busy) {
+    if (!text || busy || !selectedUserId) {
       return;
     }
 
@@ -144,6 +207,7 @@ function ChatPage() {
       await streamChat(
         {
           session_id: sessionId,
+          user_id: selectedUserId,
           message: text,
           llm_provider: llmProvider,
           tts_provider: ttsProvider,
@@ -213,6 +277,9 @@ function ChatPage() {
         ttsProvider={ttsProvider}
         characters={characters}
         characterId={characterId}
+        users={users}
+        selectedUserId={selectedUserId}
+        usersLoading={usersLoading}
         sessionId={sessionId}
         stageUrl={stageUrl}
         error={error}
@@ -224,6 +291,9 @@ function ChatPage() {
         onChangeLLM={setLLMProvider}
         onChangeTTS={setTTSProvider}
         onChangeCharacter={setCharacterId}
+        onChangeUser={setSelectedUserId}
+        onCreateUser={handleCreateUser}
+        onUpdateUser={handleUpdateUser}
       />
     </main>
   );

--- a/frontend/src/components/ChatPanel.jsx
+++ b/frontend/src/components/ChatPanel.jsx
@@ -1,3 +1,5 @@
+import { useEffect, useMemo, useState } from "react";
+
 export default function ChatPanel({
   messages,
   assistantDraft,
@@ -8,6 +10,9 @@ export default function ChatPanel({
   ttsProvider,
   characters,
   characterId,
+  users,
+  selectedUserId,
+  usersLoading,
   sessionId,
   stageUrl,
   error,
@@ -18,9 +23,16 @@ export default function ChatPanel({
   onToggleMute,
   onChangeLLM,
   onChangeTTS,
-  onChangeCharacter
+  onChangeCharacter,
+  onChangeUser,
+  onCreateUser,
+  onUpdateUser
 }) {
   const currentCharacter = characters?.find((c) => c.id === characterId) || null;
+  const selectedUser = useMemo(
+    () => users?.find((user) => user.id === selectedUserId) || null,
+    [selectedUserId, users]
+  );
   return (
     <section className="chat-panel">
       <header className="panel-header">
@@ -78,6 +90,17 @@ export default function ChatPanel({
         <p className="muted character-desc">{currentCharacter.short_description}</p>
       ) : null}
 
+      <UserProfilePanel
+        users={users}
+        selectedUser={selectedUser}
+        selectedUserId={selectedUserId}
+        loading={usersLoading}
+        busy={busy}
+        onChangeUser={onChangeUser}
+        onCreateUser={onCreateUser}
+        onUpdateUser={onUpdateUser}
+      />
+
       <div className="stage-link">
         Stage View:
         <a href={stageUrl} target="_blank" rel="noreferrer">
@@ -105,14 +128,151 @@ export default function ChatPanel({
       <form className="composer" onSubmit={onSubmit}>
         <textarea
           value={draft}
-          placeholder="輸入你想和角色說的話..."
+          placeholder={selectedUser ? "輸入你想和角色說的話..." : "請先建立或選擇使用者"}
           onChange={(event) => onDraftChange(event.target.value)}
-          disabled={busy}
+          disabled={busy || !selectedUser}
         />
-        <button type="submit" disabled={busy || !draft.trim()}>
+        <button type="submit" disabled={busy || !draft.trim() || !selectedUser}>
           {busy ? "回覆中..." : "送出"}
         </button>
       </form>
     </section>
+  );
+}
+
+function UserProfilePanel({
+  users,
+  selectedUser,
+  selectedUserId,
+  loading,
+  busy,
+  onChangeUser,
+  onCreateUser,
+  onUpdateUser
+}) {
+  const [name, setName] = useState("");
+  const [bio, setBio] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [profileError, setProfileError] = useState("");
+
+  useEffect(() => {
+    if (selectedUser) {
+      setBio(selectedUser.bio || "");
+      setName("");
+    }
+  }, [selectedUser]);
+
+  const handleCreate = async (event, createBio = bio) => {
+    event.preventDefault();
+    const cleanName = name.trim();
+    if (!cleanName) {
+      setProfileError("請輸入名稱。");
+      return;
+    }
+    setSaving(true);
+    setProfileError("");
+    try {
+      await onCreateUser({ name: cleanName, bio: createBio });
+      setName("");
+      setBio("");
+    } catch (err) {
+      setProfileError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleUpdate = async (event) => {
+    event.preventDefault();
+    if (!selectedUser) return;
+    setSaving(true);
+    setProfileError("");
+    try {
+      await onUpdateUser(selectedUser.id, {
+        name: selectedUser.name,
+        bio
+      });
+    } catch (err) {
+      setProfileError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="profile-panel muted">載入使用者...</div>;
+  }
+
+  if (!users?.length) {
+    return (
+      <form className="profile-panel profile-create" onSubmit={handleCreate}>
+        <div className="profile-title">建立使用者</div>
+        <input
+          value={name}
+          placeholder="你的名字"
+          onChange={(event) => setName(event.target.value)}
+          disabled={saving || busy}
+        />
+        <textarea
+          value={bio}
+          placeholder="簡短介紹，角色會把它當作你的基本資料"
+          onChange={(event) => setBio(event.target.value)}
+          disabled={saving || busy}
+        />
+        {profileError ? <p className="error">{profileError}</p> : null}
+        <button type="submit" disabled={saving || busy || !name.trim()}>
+          {saving ? "儲存中..." : "建立並選擇"}
+        </button>
+      </form>
+    );
+  }
+
+  return (
+    <form className="profile-panel" onSubmit={handleUpdate}>
+      <div className="profile-controls">
+        <label>
+          使用者
+          <select
+            value={selectedUserId || ""}
+            onChange={(event) => onChangeUser(Number(event.target.value) || null)}
+            disabled={busy || saving}
+          >
+            {users.map((user) => (
+              <option key={user.id} value={user.id}>
+                {user.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button type="submit" disabled={saving || busy || !selectedUser}>
+          {saving ? "儲存中..." : "更新 Bio"}
+        </button>
+      </div>
+      <textarea
+        value={bio}
+        placeholder="補充你的偏好、背景或想讓角色知道的事"
+        onChange={(event) => setBio(event.target.value)}
+        disabled={saving || busy || !selectedUser}
+      />
+      <details className="profile-add">
+        <summary>新增另一位使用者</summary>
+        <div className="profile-add-grid">
+          <input
+            value={name}
+            placeholder="新使用者名稱"
+            onChange={(event) => setName(event.target.value)}
+            disabled={saving || busy}
+          />
+          <button
+            type="button"
+            disabled={saving || busy || !name.trim()}
+            onClick={(event) => handleCreate(event, "")}
+          >
+            建立
+          </button>
+        </div>
+      </details>
+      {profileError ? <p className="error">{profileError}</p> : null}
+    </form>
   );
 }

--- a/frontend/src/components/ChatPanel.jsx
+++ b/frontend/src/components/ChatPanel.jsx
@@ -155,48 +155,41 @@ function UserProfilePanel({
   const [saving, setSaving] = useState(false);
   const [profileError, setProfileError] = useState("");
 
-  useEffect(() => {
-    if (selectedUser) {
-      setBio(selectedUser.bio || "");
-      setName("");
-    }
-  }, [selectedUser]);
+  useEffect(() => { setName(""); }, [selectedUser?.id]);
+  useEffect(() => { setBio(selectedUser?.bio || ""); }, [selectedUser?.id, selectedUser?.bio]);
 
-  const handleCreate = async (event, createBio = bio) => {
-    event.preventDefault();
-    const cleanName = name.trim();
-    if (!cleanName) {
-      setProfileError("請輸入名稱。");
-      return;
-    }
+  const withSaving = async (action) => {
     setSaving(true);
     setProfileError("");
-    try {
-      await onCreateUser({ name: cleanName, bio: createBio });
-      setName("");
-      setBio("");
-    } catch (err) {
-      setProfileError(err.message);
-    } finally {
-      setSaving(false);
-    }
+    try { await action(); }
+    catch (err) { setProfileError(err.message); }
+    finally { setSaving(false); }
   };
 
-  const handleUpdate = async (event) => {
+  const handleCreate = (event) => {
+    event.preventDefault();
+    const cleanName = name.trim();
+    if (!cleanName) { setProfileError("請輸入名稱。"); return; }
+    withSaving(async () => {
+      await onCreateUser({ name: cleanName, bio });
+      setName("");
+      setBio("");
+    });
+  };
+
+  const handleQuickAdd = () => {
+    const cleanName = name.trim();
+    if (!cleanName) { setProfileError("請輸入名稱。"); return; }
+    withSaving(async () => {
+      await onCreateUser({ name: cleanName, bio: "" });
+      setName("");
+    });
+  };
+
+  const handleUpdate = (event) => {
     event.preventDefault();
     if (!selectedUser) return;
-    setSaving(true);
-    setProfileError("");
-    try {
-      await onUpdateUser(selectedUser.id, {
-        name: selectedUser.name,
-        bio
-      });
-    } catch (err) {
-      setProfileError(err.message);
-    } finally {
-      setSaving(false);
-    }
+    withSaving(() => onUpdateUser(selectedUser.id, { name: selectedUser.name, bio }));
   };
 
   if (loading) {
@@ -266,7 +259,7 @@ function UserProfilePanel({
           <button
             type="button"
             disabled={saving || busy || !name.trim()}
-            onClick={(event) => handleCreate(event, "")}
+            onClick={handleQuickAdd}
           >
             建立
           </button>

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -11,6 +11,15 @@ function buildApiUrl(path) {
   return `${API_BASE_URL}${normalizedPath}`;
 }
 
+async function apiFetch(path, options = {}) {
+  const response = await fetch(buildApiUrl(path), options);
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`${response.status} ${message}`);
+  }
+  return response.json();
+}
+
 function parseEventBlock(block) {
   let event = "message";
   const dataLines = [];
@@ -147,52 +156,23 @@ export async function resetSession(sessionId) {
   });
 }
 
-export async function getCharacters() {
-  const response = await fetch(buildApiUrl("/api/characters"));
-  if (!response.ok) {
-    throw new Error(`Characters failed: ${response.status}`);
-  }
-  return response.json();
-}
+export const getCharacters = () => apiFetch("/api/characters");
 
-export async function getUsers() {
-  const response = await fetch(buildApiUrl("/api/users"));
-  if (!response.ok) {
-    throw new Error(`Users failed: ${response.status}`);
-  }
-  return response.json();
-}
+export const getUsers = () => apiFetch("/api/users");
 
-export async function createUser({ name, bio }) {
-  const response = await fetch(buildApiUrl("/api/users"), {
+export const createUser = ({ name, bio }) =>
+  apiFetch("/api/users", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ name, bio })
   });
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(`Create user failed: ${response.status} ${message}`);
-  }
-  return response.json();
-}
 
-export async function updateUser(userId, { name, bio }) {
-  const response = await fetch(buildApiUrl(`/api/users/${encodeURIComponent(userId)}`), {
+export const updateUser = (userId, { name, bio }) =>
+  apiFetch(`/api/users/${encodeURIComponent(userId)}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ name, bio })
   });
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(`Update user failed: ${response.status} ${message}`);
-  }
-  return response.json();
-}
 
-export async function getSessionMetrics(sessionId) {
-  const response = await fetch(buildApiUrl(`/api/session/${encodeURIComponent(sessionId)}/metrics`));
-  if (!response.ok) {
-    throw new Error(`Metrics failed: ${response.status}`);
-  }
-  return response.json();
-}
+export const getSessionMetrics = (sessionId) =>
+  apiFetch(`/api/session/${encodeURIComponent(sessionId)}/metrics`);

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,7 +1,14 @@
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || "http://localhost:8000").replace(
+  /\/+$/,
+  ""
+);
 
 function buildApiUrl(path) {
-  return `${API_BASE_URL}${path}`;
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  if (API_BASE_URL.endsWith("/api") && normalizedPath.startsWith("/api/")) {
+    return `${API_BASE_URL}${normalizedPath.slice("/api".length)}`;
+  }
+  return `${API_BASE_URL}${normalizedPath}`;
 }
 
 function parseEventBlock(block) {
@@ -144,6 +151,40 @@ export async function getCharacters() {
   const response = await fetch(buildApiUrl("/api/characters"));
   if (!response.ok) {
     throw new Error(`Characters failed: ${response.status}`);
+  }
+  return response.json();
+}
+
+export async function getUsers() {
+  const response = await fetch(buildApiUrl("/api/users"));
+  if (!response.ok) {
+    throw new Error(`Users failed: ${response.status}`);
+  }
+  return response.json();
+}
+
+export async function createUser({ name, bio }) {
+  const response = await fetch(buildApiUrl("/api/users"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, bio })
+  });
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`Create user failed: ${response.status} ${message}`);
+  }
+  return response.json();
+}
+
+export async function updateUser(userId, { name, bio }) {
+  const response = await fetch(buildApiUrl(`/api/users/${encodeURIComponent(userId)}`), {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, bio })
+  });
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`Update user failed: ${response.status} ${message}`);
   }
   return response.json();
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -199,6 +199,7 @@ body {
 
 button,
 select,
+input,
 textarea {
   font: inherit;
 }
@@ -234,6 +235,77 @@ select {
   background: rgba(0, 0, 0, 0.22);
   color: var(--text);
   padding: 4px 8px;
+}
+
+input {
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  background: rgba(0, 0, 0, 0.22);
+  color: var(--text);
+  padding: 7px 9px;
+  min-width: 0;
+}
+
+.profile-panel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 10px;
+  display: grid;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.profile-title {
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.profile-controls,
+.profile-add-grid {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  align-items: end;
+}
+
+.profile-controls label {
+  display: grid;
+  gap: 4px;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.profile-controls select {
+  width: 100%;
+}
+
+.profile-panel textarea {
+  min-height: 64px;
+  max-height: 140px;
+  resize: vertical;
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 8px;
+  background: rgba(0, 0, 0, 0.2);
+  color: var(--text);
+}
+
+.profile-create {
+  grid-template-columns: 1fr;
+}
+
+.profile-add {
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.profile-add summary {
+  cursor: pointer;
+}
+
+.profile-add-grid {
+  margin-top: 8px;
 }
 
 .stage-link {


### PR DESCRIPTION
## Main Changes

- Backend now supports users CRUD, user_id on chat requests, scoped message history by user_id +
  character_id, and a Mem0-backed long-term memory layer behind a local MemoryService.
- A memory curator step decides what is worth storing, so not every chat turn gets written to long-term
  memory.
- The frontend now has a user selector, create/edit bio UI, localStorage persistence for the selected
  user, and blocks chat submission until a user exists.
- There was also a follow-up refactor to remove duplicate helpers and redundant DB reads, plus some
  route/pipeline cleanup.